### PR TITLE
Boost dependance

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,10 +15,12 @@ else()
 endif()
 
 find_package(OpenCV REQUIRED opencv_core)
+find_package(Boost)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}
     ${OpenCV_INCLUDE_DIRS}
-    ${PYTHON_INCLUDE_DIRS})
+    ${PYTHON_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIR})
 
 enable_testing()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.0)
 
 find_package(SWIG REQUIRED)
 set(CMAKE_SWIG_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/../lib/")


### PR DESCRIPTION
Tested on Cmake VERSION 3.0. Debian x64 8 stable.
Add Boost to linking.
Fixes fatal error during make:
`Building CXX object CMakeFiles/_mat.dir/matPYTHON_wrap.cxx.o
 boost/preprocessor/repetition/repeat_from_to.hpp: Not found`

Big thanks in advance to: @renatoGarcia , @houqi 