### PR TITLE
Changed #if ! preprocessor commands to ensure newest versions of gcc are able to recognize them

### DIFF
--- a/lib/opencv/detail/numpy.i
+++ b/lib/opencv/detail/numpy.i
@@ -34,7 +34,7 @@
 %}
 
 %define %cv_numpy_add_type(type, np_basic_type)
-    #if !_CV_NUMPY_##type##_
+    #if !defined(_CV_NUMPY_##type##_)
         namespace cv
         {
             %template(_cv_numpy_sizeof_##type) _SizeOf< type >;

--- a/lib/opencv/matx.i
+++ b/lib/opencv/matx.i
@@ -43,7 +43,7 @@
 
     %cv_numpy_add_type(type, np_basic_type)
 
-    #if !_ARRAY_##type##_INSTANTIATED_
+    #if !defined(_ARRAY_##type##_INSTANTIATED_)
         %template(_##type##Array) std::vector< type >;
         %pythoncode
         {
@@ -52,7 +52,7 @@
         #define _ARRAY_##type##_INSTANTIATED_
     #endif
 
-    #if !_CV_MATX_##type##_##d1##_##d2##_INSTANTIATED_
+    #if !defined(_CV_MATX_##type##_##d1##_##d2##_INSTANTIATED_)
         %template(_Matx_##type##_##d1##_##d2) cv::Matx< type, d1, d2>;
         %pythoncode
         %{

--- a/lib/opencv/vec.i
+++ b/lib/opencv/vec.i
@@ -32,7 +32,7 @@
  *  [0]: http://docs.scipy.org/doc/numpy/reference/arrays.interface.html#__array_interface__
  */
 %define %cv_vec_instantiate(type, d1, type_alias, np_basic_type)
-    #if !_CV_VEC_##type##_##d1##_INSTANTIATED_
+    #if !defined(_CV_VEC_##type##_##d1##_INSTANTIATED_)
         %cv_matx_instantiate(type, d1, 1, type_alias, np_basic_type)
         %template(_Vec_##type##_##d1) cv::Vec< type, d1>;
         %template(_DataType_Vec_##type##_##d1) cv::DataType<cv::Vec< type, d1> >;


### PR DESCRIPTION
According to https://en.cppreference.com/w/c/preprocessor/conditional `#if` requires using define keyword to evaluate if a macro already exists. As this command was missing, gcc preprocessor was showing warnings mentioned in https://github.com/renatoGarcia/opencv-swig/issues/31